### PR TITLE
Remove mathjax extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -9,14 +9,14 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
     'sphinx.ext.imgmath',
-    "sphinx.ext.mathjax",
     "nbsphinx",
     "sphinx.ext.graphviz",
     "sphinx.ext.inheritance_diagram",
     "sphinx_autodoc_typehints"
 ]
 
-mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+imgmath_image_format = 'svg'
+imgmath_embed = True
 
 inheritance_graph_attrs = dict(rankdir="TB", size='""')
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
In the current version MathJax does not seem to work anymore or produce badly formatted equations. This PR removes MathJax and falls back to imgmath.